### PR TITLE
Modify `drawPoint()` in Soil Texture Calculator _ NRCS Soils.html

### DIFF
--- a/texture_calculator/Soil Texture Calculator _ NRCS Soils.html
+++ b/texture_calculator/Soil Texture Calculator _ NRCS Soils.html
@@ -4522,7 +4522,7 @@ dom.query = jQuery.noConflict(true);
 	</tbody>
 </table>
 </form>
-<script language="javascript">canvas = new jsGraphics("myCanvas");function drawPoint(x, y){        canvas.setColor(document.info.color.options[document.info.color.selectedIndex].value);    var xOff = 570;    var yOff = 482;    var yCoord = parseInt(yOff) - 477*parseFloat(y)*0.01;    var xCoord = parseInt(xOff) - 557*parseFloat(x)*0.01 - 0.5*parseFloat(y)*555*0.01;        canvas.fillEllipse(xCoord,yCoord,10,10);    canvas.paint();    }</script>
+<script language="javascript">canvas = new jsGraphics("myCanvas");function drawPoint(x, y){        canvas.setColor(document.info.color.options[document.info.color.selectedIndex].value);    var xOff = 565;    var yOff = 483;   var yCoord = parseInt(yOff) - 477*parseFloat(y)*0.01;    var xCoord = parseInt(xOff) - 557*parseFloat(x)*0.01 - 0.5*parseFloat(y)*555*0.01;        canvas.fillEllipse(xCoord,yCoord,10,10);    canvas.paint();    }</script>
 				
 			
 		 


### PR DESCRIPTION
It seems the centroid coordinates of the red dots plotted on the triangle are offset (in +X) from where they "should" be. Also I think they are shifted up a couple pixels on +Y / % Clay axis


Here is an example that illustrates plotting at [sand, clay] `[100, 0]` `[0, 0]` `[0, 100]`. The points are off the graph or not at the corner.

Before:
![image](https://user-images.githubusercontent.com/20842828/144901191-cfb7203c-498e-4310-8b80-b10edf73013b.png)

After a small correction to the `drawPoint()` function e.g. `var xOff = 565;    var yOff = 483;`   in https://github.com/jneme910/Soil-Texture-Calculator/blob/master/texture_calculator/Soil%20Texture%20Calculator%20_%20NRCS%20Soils.html

https://github.com/jneme910/Soil-Texture-Calculator/blob/049027ecd986cbe6c2381587ecea1319a04d4f9a/texture_calculator/Soil%20Texture%20Calculator%20_%20NRCS%20Soils.html#L4525
 or 
https://github.com/jneme910/Soil-Texture-Calculator/blob/049027ecd986cbe6c2381587ecea1319a04d4f9a/texture_calculator/ricks_files/Texture_Calculator/calculator_code.html#L52

Appears to give somewhat better alignment of corner points and areas in between. Basically keeping the same equations for scaling x and y just adjusting offsets

![image](https://user-images.githubusercontent.com/20842828/144963223-51bb16b7-f615-4ac5-bce4-68cc5ee7db8f.png)
